### PR TITLE
Updated README instructions and Underscore fix/version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
-## Install ##
+sudo npm install -g gulp
 
-- sudo npm install -g gulp-cli
-- brew install vorbis-tools, sox
 
-(In current directory)
-- npm install
-- gulp import
+At the root:
+brew install vorbis-tools
+brew install oggz
+brew install sox
+npm install
+bower install
+
+mkdir library
+mkdir inbox
+mkdir outbox
+
+drop ogg files into inbox
+At terminal, execute “gulp” to ingest the ogg files.
+
+Now execute:
+gulp server
+
+Open the browser and navigate to:
+http://localhost:8008

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "jade": "1.3.1",
     "node.extend": "^1.0.10",
     "socket.io": "^1.0.5",
-    "underscore": "^1.6.0",
+    "underscore": "1.6.0",
     "yargs": "1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Underscore templates have changes from 1.6 up, so for now it’s just set
to 1.6 directly.
